### PR TITLE
feat(purge): purge outer URLs with and without html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1870,6 +1870,51 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2669,6 +2714,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.2",
@@ -5278,6 +5333,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
@@ -6975,6 +7037,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -7286,6 +7354,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -8377,6 +8451,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "nock": {
       "version": "13.0.4",
@@ -12554,6 +12641,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -13827,6 +13931,21 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
       }
     },
     "slash": {
@@ -15336,6 +15455,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "nock": "13.0.4",
     "nyc": "15.1.0",
     "proxyquire": "2.1.3",
-    "semantic-release": "17.1.1"
+    "semantic-release": "17.1.1",
+    "sinon": "^9.0.3"
   },
   "lint-staged": {
     "*.js": "eslint"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,7 +84,7 @@ describe('Index Tests', () => {
     scope.done();
     assert.equal(result.statusCode, 200);
     assert.deepEqual(result.body, [
-      { status: 'ok', urls: ['https://blog.adobe.com/index.html','https://blog.adobe.com/index'] },
+      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
     ]);
   }).timeout(5000);
 
@@ -110,7 +110,7 @@ describe('Index Tests', () => {
     scope.done();
     assert.equal(result.statusCode, 207);
     assert.deepEqual(result.body, [
-      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
+      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
       { status: 'error', url: 'https://theblog--adobe.hlx.page/index.html' },
     ]);
   }).timeout(5000);
@@ -147,7 +147,7 @@ describe('Index Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.deepEqual(result.body, [
       { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
-      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
+      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
     ]);
   }).timeout(5000);
 
@@ -183,7 +183,7 @@ describe('Index Tests', () => {
     assert.equal(result.statusCode, 207);
     assert.deepEqual(result.body, [
       { status: 'error', url: 'https://theblog--adobe.hlx.page/index.html' },
-      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
+      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
     ]);
   }).timeout(5000);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,21 +71,20 @@ describe('Index Tests', () => {
       .reply(200, 'OK')
       .get('/ok.html')
       .reply(200, 'OK')
-      .intercept('/index.html', 'PURGE')
+      .intercept(/\/index.*/, 'PURGE')
       .reply(200)
       .persist();
 
     const result = await index({
       __ow_logger,
-      xfh: 'blog.adobe.com, theblog--adobe.hlx.page',
+      xfh: 'blog.adobe.com',
       path: '/index.html',
     });
 
     scope.done();
     assert.equal(result.statusCode, 200);
     assert.deepEqual(result.body, [
-      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
-      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
+      { status: 'ok', urls: ['https://blog.adobe.com/index.html','https://blog.adobe.com/index'] },
     ]);
   }).timeout(5000);
 
@@ -96,6 +95,8 @@ describe('Index Tests', () => {
       .get('/ok.html')
       .reply(200, 'OK')
       .intercept('/index.html', 'PURGE')
+      .reply(200)
+      .intercept('/index', 'PURGE')
       .reply(200)
       .intercept('/index.html', 'PURGE')
       .reply(504);
@@ -109,7 +110,7 @@ describe('Index Tests', () => {
     scope.done();
     assert.equal(result.statusCode, 207);
     assert.deepEqual(result.body, [
-      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
+      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
       { status: 'error', url: 'https://theblog--adobe.hlx.page/index.html' },
     ]);
   }).timeout(5000);
@@ -120,7 +121,7 @@ describe('Index Tests', () => {
       .reply(200, 'OK')
       .get('/ok.html')
       .reply(200, 'OK')
-      .intercept('/index.html', 'PURGE')
+      .intercept(/\/index.*/, 'PURGE')
       .reply(200)
       .persist()
       .post('/service/test-service/purge')
@@ -146,8 +147,7 @@ describe('Index Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.deepEqual(result.body, [
       { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
-      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
-      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
+      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
     ]);
   }).timeout(5000);
 
@@ -157,7 +157,7 @@ describe('Index Tests', () => {
       .reply(200, 'OK')
       .get('/ok.html')
       .reply(200, 'OK')
-      .intercept('/index.html', 'PURGE')
+      .intercept(/\/index.*/, 'PURGE')
       .reply(200)
       .persist()
       .post('/service/test-service/purge')
@@ -183,8 +183,7 @@ describe('Index Tests', () => {
     assert.equal(result.statusCode, 207);
     assert.deepEqual(result.body, [
       { status: 'error', url: 'https://theblog--adobe.hlx.page/index.html' },
-      { status: 'ok', url: 'https://blog.adobe.com/index.html' },
-      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
+      { status: 'ok', urls: ['https://blog.adobe.com/index.html', 'https://blog.adobe.com/index'] },
     ]);
   }).timeout(5000);
 });


### PR DESCRIPTION
Fix #12 

@trieloff I also noticed that the inner CDN ended up getting double purged using `outerPurge()` if the inner hostname was present in `xfh`. Assuming this was unintentional, I added a check to skip URLs with the inner host and not use `outerPurge()` on it again. Please double-check and let me know if I misunderstood that.