### PR TITLE
fix: breaking change in pipeline returns altered output for main section

### DIFF
--- a/ok.html
+++ b/ok.html
@@ -4,19 +4,19 @@
   <title>Helix Pages is OK, commence purging!</title>
   <meta name="x-source-hash" content="/6reu3l0cDEDh5ks">
   <link rel="canonical" href="https://main--helix-purge--adobe.hlx.page/OK.html">
-
+  
   <meta property="og:title" content="Helix Pages is OK, commence purging!">
-
+  
   <meta property="og:url" content="https://main--helix-purge--adobe.hlx.page/OK.html">
   <meta property="og:image" content="https://main--helix-purge--adobe.hlx.page/default-meta-image.png">
   <meta property="og:image:secure_url" content="https://main--helix-purge--adobe.hlx.page/default-meta-image.png">
-
-
-
-
-
+  
+  
+  
+  
+  
   <meta name="twitter:title" content="Helix Pages is OK, commence purging!">
-
+  
   <meta name="twitter:image" content="https://main--helix-purge--adobe.hlx.page/default-meta-image.png">
   <link rel="stylesheet" href="/style.css"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>

--- a/ok.html
+++ b/ok.html
@@ -51,7 +51,7 @@
   <!--  header -->
   <header></header>
   <!--  main content -->
-  <main><div class="default"><p>Helix Pages is <strong>OK</strong>, commence purging!</p></div></main>
+  <main><div><p>Helix Pages is <strong>OK</strong>, commence purging!</p></div></main>
   <!--  footer -->
   <footer></footer>
 </body>


### PR DESCRIPTION
The static response for `ok.html` has started to differ from the dynamic one after the breaking change to pipeline:
```
$ diff OK.html ok.html
<   <main><div><p>Helix Pages is <strong>OK</strong>, commence purging!</p></div></main>
---
>   <main><div class="default"><p>Helix Pages is <strong>OK</strong>, commence purging!</p></div></main>
```
This change will make the output of the two identical again.