### PR TITLE
fix(index): do not dedupe the inner cdn purge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ async function main(req, context) {
   results.push(...await Promise.all(Array.from(new Set(xfh
     .split(',')
     .map((fwhost) => fwhost.trim())
-    .filter((fwhost) => !!fwhost)
+    .filter((fwhost) => !!fwhost)))
     .map((fwhost) => purgeOuter(fwhost, path, log))));
 
   if (results.length === 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,6 @@ async function main(req, context) {
     .split(',')
     .map((fwhost) => fwhost.trim())
     .filter((fwhost) => !!fwhost)
-    .filter((fwhost) => fwhost !== host))) // skip inner CDN host
     .map((fwhost) => purgeOuter(fwhost, path, log))));
 
   if (results.length === 0) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -223,6 +223,7 @@ describe('Index Tests', () => {
     assert.deepStrictEqual(result.body, [
       { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
       { status: 'ok', url: 'https://blog.adobe.com/index.html' },
+      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
     ]);
   }).timeout(5000);
 
@@ -253,6 +254,7 @@ describe('Index Tests', () => {
     assert.deepStrictEqual(result.body, [
       { status: 'error', url: 'https://theblog--adobe.hlx.page/index.html' },
       { status: 'ok', url: 'https://blog.adobe.com/index.html' },
+      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
     ]);
   }).timeout(5000);
 
@@ -284,6 +286,7 @@ describe('Index Tests', () => {
       { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
       { status: 'ok', url: 'https://blog.adobe.com/index.html' },
       { status: 'ok', url: 'https://theblog--adobe.hlx.live/index.html' },
+      { status: 'ok', url: 'https://theblog--adobe.hlx.page/index.html' },
     ]);
   }).timeout(5000);
 });


### PR DESCRIPTION
the inner cdn purge is api-based by default, but this can lead to a slowdown as the fastly api is sometimes slow and as the fastly api is asynchronous (other than the PURGE request), so without the deduplication we will get more consistent purges

fixes #112
