### PR TITLE
fix(http): disable http/2 on adobe io runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+// eslint-disable-next-line no-underscore-dangle
+process.env.HELIX_FETCH_FORCE_HTTP1 = process.env.__OW_ACTIVATION_ID;
+
 const { wrap } = require('@adobe/openwhisk-action-utils');
 const { logger } = require('@adobe/openwhisk-action-logger');
 const { wrap: status } = require('@adobe/helix-status');


### PR DESCRIPTION
just like helix-publish, there seem to be issues with helix-purge using http/2 on adobe i/o runtime (https://helix.coralogix.com/#/query/logs?id=2IzFOAvVHGE) such as 

`Unable to purge inner CDN AbortError: Aborted post request to /service/1McGRQOYFuABWBHyD8D4Ux/purge/tGVjEvDTy7+jnHUw after 0 retries and 15009 ms: The operation was aborted.\n at EventEmitter.abortHandler (/nodejsAction/f7DA2oiy/index.js:7325:17)\n at EventEmitter.emit (events.js:310:20)\n at AbortSignal.dispatchEvent (/nodejsAction/f7DA2oiy/index.js:6489:41)\n at AbortSignal.fire (/nodejsAction/f7DA2oiy/index.js:6494:10)\n at AbortController.abort (/nodejsAction/f7DA2oiy/index.js:6533:39)\n at Timeout._onTimeout (/nodejsAction/f7DA2oiy/index.js:7528:16)\n at listOnTimeout (internal/timers.js:549:17)\n at processTimers (internal/timers.js:492:7) {\n type: 'aborted',\n bufferedData: <Buffer 7b 20 22 73 74 61 74 75 73 22 3a 20 22 6f 6b 22 2c 20 22 69 64 22 3a 20 22 32 31 30 32 33 2d 31 36 31 34 33 31 36 39 34 38 2d 39 33 35 39 31 30 22 20 ... 1 more byte>\n}` 

and 

`Unable to purge inner CDN FetchError: The socket is already bound to an Http2Session\n at fetch (/nodejsAction/f7DA2oiy/index.js:7318:11) {\n type: 'system',\n errno: 'ERR_HTTP2_SOCKET_BOUND',\n code: 'ERR_HTTP2_SOCKET_BOUND',\n erroredSysCall: undefined\n}`
