### PR TITLE
chore: switch to universal monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
       # see https://circleci.com/orbs/registry/orb/adobe/helix-post-deploy
       # for more available parameters
       - helix-post-deploy/monitoring:
+          targets: universal, aws, adobeio
           statuspage_name: Helix Purge
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure


### PR DESCRIPTION
Related to the latest outage - we no longer use Runtime for `helix-purge` by default, so it should be removed from PD as well.

see also https://github.com/adobe/helix-publish/issues/902